### PR TITLE
Fix highlighting parts of variable names as keywords

### DIFF
--- a/syntaxes/circom.tmLanguage
+++ b/syntaxes/circom.tmLanguage
@@ -729,7 +729,7 @@
     <!-->// TODO:Circom specific language <--> 
     <dict>
 			<key>match</key>
-			<string>output|signal|input|component|template</string>
+			<string>\b(output|signal|input|component|template)\b</string>
 			<key>name</key>
 			<string>storage.type.js</string>
 		</dict>


### PR DESCRIPTION
Before:
<img width="461" alt="image" src="https://user-images.githubusercontent.com/2109710/77639779-51ee2700-6f6a-11ea-8266-425f18ac6089.png">

After:
<img width="462" alt="image" src="https://user-images.githubusercontent.com/2109710/77639522-f15eea00-6f69-11ea-91cb-c589fbbc1c00.png">
