### PR TITLE
Fix grammar compilation because of incorrectly escaped XML char

### DIFF
--- a/syntaxes/circom.tmLanguage
+++ b/syntaxes/circom.tmLanguage
@@ -741,7 +741,7 @@
 		</dict>
     <dict>
 			<key>match</key>
-			<string> === | <-- | --> | <== | ==> </string>
+			<string> === | &lt;-- | --&gt; | &lt;== | ==&gt; </string>
 			<key>name</key>
 			<string>support.class.js</string>
 		</dict>


### PR DESCRIPTION
The grammar doesn't currently compile because of an unescaped `<` and `>`. This PR fixes this.